### PR TITLE
Fix duplicate text in instruction

### DIFF
--- a/instructions.md
+++ b/instructions.md
@@ -1,5 +1,3 @@
-Ripple
-
 ## 👋 Welcome to Ripple
 
 ### Island


### PR DESCRIPTION
Remove 'Ripple' heading from instructions.