### PR TITLE
fix: resolve Windows app launching and argument parsing issues (#28)

### DIFF
--- a/src/Island.jsx
+++ b/src/Island.jsx
@@ -31,15 +31,44 @@ const WeatherIcon = ({ status, size = 16, color = "currentColor" }) => {
 function openApp(app) {
   if (!app) return;
   const trimmedApp = app.trim();
-  const hasProtocol = /^[a-z0-9-]+:\/\//i.test(trimmedApp);
-  const isUrl = /^https?:\/\//i.test(trimmedApp) || trimmedApp.includes('.');
 
-  if (hasProtocol || isUrl) {
-    const target = (isUrl && !hasProtocol) ? `https://${trimmedApp}` : trimmedApp;
-    window.electronAPI?.openExternal(target);
-  } else {
-    window.electronAPI?.launchApp(trimmedApp);
+  // 1. Explicit protocol URLs — checked first so that file:// and https://
+  //    aren't accidentally caught by the path-separator test below.
+  if (/^(https?|file):\/\//i.test(trimmedApp)) {
+    window.electronAPI?.openExternal(trimmedApp);
+    return;
   }
+
+  // 2. Launch targets — exe paths, UNC paths, shell: URIs.
+  //    Checked before any dot-based heuristic so .exe and AppID dots never
+  //    trip URL detection.
+  const isLaunchTarget =
+    /[\\\/]/.test(trimmedApp)  ||   // path separator → exe path or UNC
+    /\.exe$/i.test(trimmedApp) ||   // bare name ending in .exe
+    trimmedApp.startsWith('shell:'); // UWP shell URI
+
+  if (isLaunchTarget) {
+    window.electronAPI?.launchApp(trimmedApp);
+    return;
+  }
+
+  // 3. IPv4 address or localhost → open in browser via http://
+  //    (dev servers rarely run https)
+  if (/^(\d{1,3}\.){3}\d{1,3}(:\d+)?(\/.*)?$/.test(trimmedApp) ||
+      /^localhost(:\d+)?(\/.*)?$/i.test(trimmedApp)) {
+    window.electronAPI?.openExternal(`http://${trimmedApp}`);
+    return;
+  }
+
+  // 4. Bare domain — must end with 2+ alpha chars so python3.11 and
+  //    192.168.1.1 are not misclassified. DO NOT use .includes('.').
+  if (/^[a-z0-9.-]+\.[a-z]{2,}$/i.test(trimmedApp)) {
+    window.electronAPI?.openExternal(`https://${trimmedApp}`);
+    return;
+  }
+
+  // 5. Everything else — treat as a command or app name
+  window.electronAPI?.launchApp(trimmedApp);
 }
 
 export default function Island() {
@@ -243,8 +272,21 @@ export default function Island() {
   let width = mode === "large" ? (currentTab === 7 ? 480 : currentTab === 1 ? 480 : currentTab === 3 ? 330 : currentTab === 0 ? 405 : 380) : (mode === "quick" || alert || chargingAlert || bluetoothAlert) ? 300 : isPlaying ? 265 : 170;
   let height = mode === "large" ? (currentTab === 7 ? (positionMode === "free" ? 410 : 330) : currentTab === 6 ? 250 : currentTab === 3 ? 150 : currentTab === 0 ? 120 : 190) : 43;
 
-  const [quickApps, setQuickApps] = useState(JSON.parse(localStorage.getItem("quick-apps") || '["Notes", "Spotify", "Calculator", "Terminal"]'));
+  const normalizeApps = (arr) => arr.map(a => typeof a === 'string' ? { name: a, launch: a } : a);
+  const [quickApps, setQuickApps] = useState(() =>
+    normalizeApps(JSON.parse(localStorage.getItem("quick-apps") || '["Notes", "Spotify", "Calculator", "Terminal"]'))
+  );
   const [newQuickApp, setNewQuickApp] = useState("");
+  const [appSuggestions, setAppSuggestions] = useState([]);
+  const [showSuggestions, setShowSuggestions] = useState(false);
+  const selectedAppRef = useRef(null);
+  const appSearchTimer = useRef(null);
+
+  useEffect(() => {
+    if (window.electronAPI?.platform === 'win32') {
+      window.electronAPI?.buildAppCache?.();
+    }
+  }, []);
 
   useEffect(() => {
     const savedDisplayId = localStorage.getItem("display-id");
@@ -423,17 +465,20 @@ export default function Island() {
 
   const handleQaChange = (index, value) => {
     const updatedApps = [...quickApps];
-    updatedApps[index] = value;
+    updatedApps[index] = { name: value, launch: value };
     setQuickApps(updatedApps);
     localStorage.setItem("quick-apps", JSON.stringify(updatedApps));
   };
 
   const addQuickApp = () => {
     if (newQuickApp.trim()) {
-      const updatedApps = [...quickApps, newQuickApp.trim()];
+      const entry = selectedAppRef.current || { name: newQuickApp.trim(), launch: newQuickApp.trim() };
+      const updatedApps = [...quickApps, entry];
       setQuickApps(updatedApps);
       localStorage.setItem("quick-apps", JSON.stringify(updatedApps));
       setNewQuickApp("");
+      selectedAppRef.current = null;
+      setShowSuggestions(false);
     }
   };
 
@@ -1253,10 +1298,10 @@ export default function Island() {
                     <AnimatePresence>
                       {quickApps.map((app, i) => (
                         <motion.button
-                          key={`main-qa-${app}-${i}`}
+                          key={`main-qa-${app.name}-${i}`}
                           className="qa-app"
                           onClick={() => {
-                            openApp(app);
+                            openApp(app.launch);
                           }}
                           initial={{ opacity: 0 }}
                           animate={{ opacity: 1 }}
@@ -1268,7 +1313,7 @@ export default function Island() {
                             flexShrink: 0
                           }}
                         >
-                          {app}
+                          {app.name}
                         </motion.button>
                       ))}
                     </AnimatePresence>
@@ -2048,39 +2093,97 @@ export default function Island() {
 
                 <div className="settings-section">
                   <h3 style={{ fontSize: 13, textTransform: 'uppercase', opacity: 0.5, letterSpacing: '0.05em' }}>Quick Apps</h3>
-                  <div style={{ display: 'flex', gap: '8px', marginBottom: '12px' }}>
-                    <input
-                      className="select-input"
-                      style={{ flex: 1 }}
-                      value={newQuickApp}
-                      placeholder="Add app (e.g. Mail)"
-                      onChange={(e) => setNewQuickApp(e.target.value)}
-                    />
-                    <button
-                      onClick={() => {
-                        addQuickApp();
-                      }}
-                      style={{
-                        backgroundColor: textColor,
-                        color: bgColor,
-                        border: 'none',
+                  <div style={{ display: 'flex', gap: '8px', marginBottom: '12px', position: 'relative', flexDirection: 'column' }}>
+                    <div style={{ display: 'flex', gap: '8px' }}>
+                      <input
+                        className="select-input"
+                        style={{ flex: 1 }}
+                        value={newQuickApp}
+                        placeholder="Add app (e.g. Apple Music)"
+                        onChange={(e) => {
+                          const val = e.target.value;
+                          setNewQuickApp(val);
+                          selectedAppRef.current = null;
+                          clearTimeout(appSearchTimer.current);
+                          if (window.electronAPI?.platform === 'win32' && val.trim().length > 1) {
+                            appSearchTimer.current = setTimeout(async () => {
+                              const results = await window.electronAPI.searchApps(val.trim());
+                              setAppSuggestions(results);
+                              setShowSuggestions(results.length > 0);
+                            }, 200);
+                          } else {
+                            setAppSuggestions([]);
+                            setShowSuggestions(false);
+                          }
+                        }}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter') addQuickApp();
+                          if (e.key === 'Escape') setShowSuggestions(false);
+                        }}
+                        onBlur={() => setTimeout(() => setShowSuggestions(false), 150)}
+                      />
+                      <button
+                        onClick={addQuickApp}
+                        style={{
+                          backgroundColor: textColor,
+                          color: bgColor,
+                          border: 'none',
+                          borderRadius: '12px',
+                          padding: '8px 12px',
+                          fontWeight: 600,
+                          cursor: 'pointer',
+                          display: 'flex',
+                          alignItems: 'center',
+                          justifyContent: 'center'
+                        }}
+                      >
+                        <Plus size={18} />
+                      </button>
+                    </div>
+                    {showSuggestions && appSuggestions.length > 0 && (
+                      <div style={{
+                        position: 'absolute',
+                        top: '100%',
+                        left: 0,
+                        right: 0,
+                        zIndex: 999,
                         borderRadius: '12px',
-                        padding: '8px 12px',
-                        fontWeight: 600,
-                        cursor: 'pointer',
-                        display: 'flex',
-                        alignItems: 'center',
-                        justifyContent: 'center'
-                      }}
-                    >
-                      <Plus size={18} />
-                    </button>
+                        overflow: 'hidden',
+                        boxShadow: '0 4px 20px rgba(0,0,0,0.3)',
+                        backgroundColor: bgColor,
+                        border: `1px solid ${textColor}22`,
+                        marginTop: '4px'
+                      }}>
+                        {appSuggestions.map((s, i) => (
+                          <div
+                            key={i}
+                            onMouseDown={() => {
+                              selectedAppRef.current = s;
+                              setNewQuickApp(s.name);
+                              setShowSuggestions(false);
+                            }}
+                            style={{
+                              padding: '8px 12px',
+                              cursor: 'pointer',
+                              color: textColor,
+                              fontSize: 13,
+                              borderBottom: i < appSuggestions.length - 1 ? `1px solid ${textColor}11` : 'none',
+                            }}
+                            onMouseEnter={e => e.currentTarget.style.backgroundColor = `${textColor}11`}
+                            onMouseLeave={e => e.currentTarget.style.backgroundColor = 'transparent'}
+                          >
+                            <div style={{ fontWeight: 600 }}>{s.name}</div>
+                            <div style={{ opacity: 0.4, fontSize: 11, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{s.launch}</div>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                   </div>
                   <div style={{ display: 'flex', flexDirection: 'column', gap: '5px' }}>
                     <AnimatePresence>
                       {quickApps.map((app, idx) => (
                         <motion.div
-                          key={`qa-${app}-${idx}`}
+                          key={`qa-${idx}`}
                           className="settings-row"
                           style={{ justifyContent: 'space-between', padding: '5px 0' }}
                           initial={{ opacity: 0, height: 0 }}
@@ -2091,7 +2194,7 @@ export default function Island() {
                           <input
                             className="select-input"
                             style={{ flex: 1, border: 'none', background: 'transparent', padding: 0 }}
-                            value={app}
+                            value={app.name}
                             onChange={(e) => handleQaChange(idx, e.target.value)}
                           />
                           <button

--- a/src/main.js
+++ b/src/main.js
@@ -1,21 +1,269 @@
 "use strict";
-const { app, BrowserWindow, screen, ipcMain, shell, Tray, Menu, nativeImage } = require("electron");
+const {
+  app,
+  BrowserWindow,
+  screen,
+  ipcMain,
+  shell,
+  Tray,
+  Menu,
+  nativeImage,
+} = require("electron");
 const path = require("node:path");
 const fs = require("fs");
 
-if (process.platform === 'linux') {
-  app.commandLine.appendSwitch('enable-transparent-visuals');
-  app.commandLine.appendSwitch('disable-gpu-compositing');
+if (process.platform === "linux") {
+  app.commandLine.appendSwitch("enable-transparent-visuals");
+  app.commandLine.appendSwitch("disable-gpu-compositing");
   app.disableHardwareAcceleration();
 }
 let tray = null;
 let mainWindow = null;
 
-const { exec } = require('child_process');
+const { exec, spawn } = require('child_process');
 
-ipcMain.handle('set-ignore-mouse-events', (event, ignore, forward) => {
+// --- App discovery providers ---
+
+// Scans Start Menu .lnk files and resolves them to Win32 exe paths.
+// Skips shortcuts targeting explorer.exe (UWP launchers) or WindowsApps.
+function discoverStartMenu() {
+  return new Promise((resolve) => {
+    const script = `
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$shell   = New-Object -ComObject WScript.Shell
+$dirs    = @("$env:ProgramData\\Microsoft\\Windows\\Start Menu\\Programs","$env:APPDATA\\Microsoft\\Windows\\Start Menu\\Programs")
+$results = [System.Collections.Generic.List[object]]::new()
+foreach ($dir in $dirs) {
+  if (-not (Test-Path $dir)) { continue }
+  Get-ChildItem $dir -Recurse -Filter '*.lnk' -EA SilentlyContinue | ForEach-Object {
+    try {
+      $target = $shell.CreateShortcut($_.FullName).TargetPath
+      if ($target -and $target.EndsWith('.exe') -and
+          $target -notlike '*\\\\explorer.exe' -and
+          $target -notmatch 'WindowsApps' -and
+          (Test-Path $target -EA SilentlyContinue)) {
+        $results.Add([PSCustomObject]@{ name = $_.BaseName; type = 'win32'; path = $target })
+      }
+    } catch {}
+  }
+}
+@($results) | ConvertTo-Json -Compress -Depth 2
+`;
+    const enc = Buffer.from(script, "utf16le").toString("base64");
+    exec(
+      `powershell -NoProfile -EncodedCommand ${enc}`,
+      { maxBuffer: 5 * 1024 * 1024 },
+      (err, out) => {
+        if (err || !out) return resolve([]);
+        try {
+          const d = JSON.parse(out.trim());
+          resolve(Array.isArray(d) ? d : d ? [d] : []);
+        } catch {
+          resolve([]);
+        }
+      },
+    );
+  });
+}
+
+// Gets UWP / Store apps via Get-StartApps.
+// UWP entries have AppID in the form PackageFamilyName!AppId (contains '!').
+function discoverUWP() {
+  return new Promise((resolve) => {
+    const script = `
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$results = [System.Collections.Generic.List[object]]::new()
+Get-StartApps -EA SilentlyContinue | ForEach-Object {
+  if ($_.AppID -match '.+!.+') {
+    $results.Add([PSCustomObject]@{ name = $_.Name; type = 'uwp'; appId = $_.AppID })
+  }
+}
+@($results) | ConvertTo-Json -Compress -Depth 2
+`;
+    const enc = Buffer.from(script, "utf16le").toString("base64");
+    exec(
+      `powershell -NoProfile -EncodedCommand ${enc}`,
+      { maxBuffer: 2 * 1024 * 1024 },
+      (err, out) => {
+        if (err || !out) return resolve([]);
+        try {
+          const d = JSON.parse(out.trim());
+          resolve(Array.isArray(d) ? d : d ? [d] : []);
+        } catch {
+          resolve([]);
+        }
+      },
+    );
+  });
+}
+
+// Converts provider-specific shapes to { name, launch } and deduplicates.
+// win32: launch = exe path   |   uwp: launch = shell:AppsFolder\\appId
+async function buildCache() {
+  const [startMenu, uwp] = await Promise.all([
+    discoverStartMenu(),
+    discoverUWP(),
+  ]);
+  const seen = new Set();
+  const entries = [];
+  for (const item of [...startMenu, ...uwp]) {
+    if (!item.name || !(item.path || item.appId)) continue;
+    const launch =
+      item.type === "uwp" ? `shell:AppsFolder\\${item.appId}` : item.path;
+    const key = launch.toLowerCase();
+    if (!seen.has(key)) {
+      seen.add(key);
+      entries.push({ name: item.name, launch });
+    }
+  }
+  return entries.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+// Tokenizes an argument string, correctly handling mid-token quotes.
+// --flag="hello world"  ->  ['--flag=hello world']
+// "quoted arg" --bare   ->  ['quoted arg', '--bare']
+function tokenizeArgs(str) {
+  const args = [];
+  let i = 0;
+  while (i < str.length) {
+    while (i < str.length && /\s/.test(str[i])) i++;
+    if (i >= str.length) break;
+    let token = "";
+    while (i < str.length && !/\s/.test(str[i])) {
+      if (str[i] === '"') {
+        i++;
+        while (i < str.length && str[i] !== '"') token += str[i++];
+        if (i < str.length) i++; // consume closing quote
+      } else {
+        token += str[i++];
+      }
+    }
+    if (token) args.push(token);
+  }
+  return args;
+}
+
+// Parses a Windows command string into { exe, args }.
+// Normalizes forward slashes and expands %ENV_VAR% before splitting.
+function parseCommand(input) {
+  const prepared = input
+    .replace(/\//g, "\\")
+    .replace(/%([^%]+)%/g, (_, v) => process.env[v] || `%${v}%`);
+
+  // Quoted exe path: "C:\path with spaces\app.exe" [args...]
+  const quotedMatch = prepared.match(/^"([^"]+)"(.*)/);
+  if (quotedMatch) {
+    return {
+      exe: quotedMatch[1],
+      args: quotedMatch[2].trim() ? tokenizeArgs(quotedMatch[2].trim()) : [],
+    };
+  }
+
+  // Unquoted path: find exe boundary by known extension so that spaces inside
+  // the path (C:\Program Files\...) don't cause premature splitting.
+  const extMatch = prepared.match(
+    /^(.+?\.(?:exe|cmd|bat|com|ps1))(?:\s+(.*))?$/i,
+  );
+  if (extMatch) {
+    return {
+      exe: extMatch[1],
+      args: extMatch[2] ? tokenizeArgs(extMatch[2]) : [],
+    };
+  }
+
+  // No recognised extension (e.g. cmd, wt) — split on first whitespace.
+  const spaceIdx = prepared.search(/\s/);
+  if (spaceIdx === -1) return { exe: prepared, args: [] };
+  return {
+    exe: prepared.slice(0, spaceIdx),
+    args: tokenizeArgs(prepared.slice(spaceIdx + 1).trim()),
+  };
+}
+
+// --- Launch abstraction ---
+function launchWindows(input) {
+  const trimmed = input.trim();
+
+  // UWP apps and schemes
+  if (trimmed.startsWith("shell:")) {
+    const safe = trimmed.replace(/'/g, "''");
+    exec(
+      `powershell -NoProfile -WindowStyle Hidden -Command "Start-Process '${safe}'"`,
+    );
+    return;
+  }
+
+  // Paths with slashes (ex: C:\Program Files\App.exe)
+  if (/[\\\/]/.test(trimmed)) {
+    const { exe, args } = parseCommand(trimmed);
+
+    // If no arguments, use native OS approach for best compatibility
+    if (args.length === 0) {
+      if (exe.toLowerCase().endsWith(".url")) {
+        try {
+          const content = fs.readFileSync(exe, "utf8");
+          const m = content.match(/^URL=(.+)$/im);
+          if (m) shell.openExternal(m[1].trim());
+        } catch {}
+        return;
+      }
+      shell.openPath(exe).then((err) => {
+        if (err) exec(`start "" "${exe}"`);
+      });
+      return;
+    }
+
+    // Arguments provided - spawn exactly to prevent execution escaping vulnerabilities
+    const finalExe = /[\\/]/.test(exe) && !/\.[^\\.]+$/.test(exe) ? exe + ".exe" : exe;
+
+    // cmd / bat scripts must run via cmd.exe
+    if (/\.(cmd|bat)$/i.test(finalExe)) {
+      const child = spawn("cmd.exe", ["/c", finalExe, ...args], {
+        shell: false,
+        detached: true,
+        stdio: "ignore",
+      });
+      child.on("error", () => {});
+      child.unref();
+      return;
+    }
+
+    // powershell scripts
+    if (/\.ps1$/i.test(finalExe)) {
+      const child = spawn(
+        "powershell.exe",
+        ["-NoProfile", "-ExecutionPolicy", "Bypass", "-File", finalExe, ...args],
+        { shell: false, detached: true, stdio: "ignore" },
+      );
+      child.on("error", () => {});
+      child.unref();
+      return;
+    }
+
+    const child = spawn(finalExe, args, {
+      shell: false,
+      detached: true,
+      stdio: "ignore",
+    });
+    child.on("error", () => {}); 
+    child.unref();
+    return;
+  }
+
+  // App Paths or raw executables
+  if (trimmed.includes(" ")) {
+    const safe = trimmed.replace(/'/g, "''");
+    exec(
+      `powershell -NoProfile -WindowStyle Hidden -Command "Start-Process '${safe}'"`,
+    );
+  } else {
+    exec(`start "" ${trimmed}`);
+  }
+}
+
+ipcMain.handle("set-ignore-mouse-events", (event, ignore, forward) => {
   if (mainWindow) {
-    if (process.platform !== 'linux') {
+    if (process.platform !== "linux") {
       mainWindow.setIgnoreMouseEvents(ignore, { forward: forward || false });
     } else {
       mainWindow.setIgnoreMouseEvents(ignore);
@@ -23,43 +271,71 @@ ipcMain.handle('set-ignore-mouse-events', (event, ignore, forward) => {
   }
 });
 
-ipcMain.handle('focus-window', () => {
+ipcMain.handle("focus-window", () => {
   if (mainWindow) {
     mainWindow.focus();
   }
 });
 
-ipcMain.handle('open-external', async (event, url) => {
+ipcMain.handle("open-external", async (event, url) => {
   await shell.openExternal(url);
 });
 
-ipcMain.handle('launch-app', async (event, appName) => {
+ipcMain.handle("launch-app", async (event, appName) => {
   const platform = process.platform;
-  if (platform === 'darwin') {
+  if (platform === "darwin") {
     exec(`open -a "${appName}"`);
-  } else if (platform === 'win32') {
-    exec(`start "" "${appName}"`);
+  } else if (platform === "win32") {
+    launchWindows(appName);
   } else {
     exec(appName);
   }
 });
 
-ipcMain.handle('get-displays', () => {
+ipcMain.handle("build-app-cache", async () => {
+  if (process.platform !== "win32") return;
+  const cacheFile = path.join(app.getPath("userData"), "app-cache.json");
+  try {
+    const entries = await buildCache();
+    fs.writeFileSync(cacheFile, JSON.stringify(entries));
+  } catch {
+    // Silently ignore cache build failures
+  }
+});
+
+ipcMain.handle("search-apps", async (event, query) => {
+  if (process.platform !== "win32" || !query) return [];
+  const cacheFile = path.join(app.getPath("userData"), "app-cache.json");
+  try {
+    if (!fs.existsSync(cacheFile)) return [];
+    const data = JSON.parse(fs.readFileSync(cacheFile, "utf8"));
+    const q = query.toLowerCase();
+    return data
+      .filter((a) => a.name && a.name.toLowerCase().includes(q))
+      .slice(0, 8);
+  } catch {
+    return [];
+  }
+});
+
+ipcMain.handle("get-displays", () => {
   const displays = screen.getAllDisplays();
-  return displays.map(d => ({
+  return displays.map((d) => ({
     id: d.id,
     label: d.label || `Display ${d.id}`,
-    bounds: d.bounds
+    bounds: d.bounds,
   }));
 });
 
-ipcMain.handle('set-display', (event, displayId) => {
+ipcMain.handle("set-display", (event, displayId) => {
   if (mainWindow) {
     const displays = screen.getAllDisplays();
-    const targetDisplay = displays.find(d => d.id.toString() === displayId.toString()) || screen.getPrimaryDisplay();
+    const targetDisplay =
+      displays.find((d) => d.id.toString() === displayId.toString()) ||
+      screen.getPrimaryDisplay();
 
     const { x, y, width, height } = targetDisplay.bounds;
-    const isLinux = process.platform === 'linux';
+    const isLinux = process.platform === "linux";
 
     mainWindow.setBounds({ x, y, width, height });
     if (!isLinux) {
@@ -71,12 +347,16 @@ ipcMain.handle('set-display', (event, displayId) => {
   }
 });
 
-ipcMain.handle('update-window-position', (event, xPerc, yPx) => { });
+ipcMain.handle("update-window-position", (event, xPerc, yPx) => {});
 
-ipcMain.handle('set-auto-launch', (event, enable) => {
-  if (process.platform === 'linux') {
-    const autostartPath = path.join(app.getPath('home'), '.config', 'autostart');
-    const desktopFilePath = path.join(autostartPath, 'ripple.desktop');
+ipcMain.handle("set-auto-launch", (event, enable) => {
+  if (process.platform === "linux") {
+    const autostartPath = path.join(
+      app.getPath("home"),
+      ".config",
+      "autostart",
+    );
+    const desktopFilePath = path.join(autostartPath, "ripple.desktop");
 
     try {
       if (enable) {
@@ -88,8 +368,7 @@ Type=Application
 Version=1.0
 Name=Ripple
 Comment=Ripple Desktop Assistant
-Exec="${app.getPath('exe')}"
-Icon=${getIconPath()}
+Exec="${app.getPath("exe")}"\nIcon=${getIconPath()}
 Terminal=false
 `;
         fs.writeFileSync(desktopFilePath, desktopFileContent);
@@ -99,25 +378,28 @@ Terminal=false
         }
       }
     } catch (e) {
-      console.error('Failed to set auto-launch on Linux:', e);
+      console.error("Failed to set auto-launch on Linux:", e);
     }
-  } else if (process.platform === 'win32') {
+  } else if (process.platform === "win32") {
     try {
       app.setLoginItemSettings({
         openAtLogin: enable,
-        path: app.getPath('exe'),
+        path: app.getPath("exe"),
       });
     } catch (e) {
-      console.error('Failed to set login item settings on Windows:', e);
+      console.error("Failed to set login item settings on Windows:", e);
     }
   }
 });
 
 const getIconPath = () => {
-  const ext = 'png';
+  const ext = "png";
   if (app.isPackaged) {
     const resPath = path.join(process.resourcesPath, `icon.${ext}`);
-    const assetsPath = path.join(process.resourcesPath, `assets/icons/icon.${ext}`);
+    const assetsPath = path.join(
+      process.resourcesPath,
+      `assets/icons/icon.${ext}`,
+    );
 
     if (fs.existsSync(resPath)) return resPath;
     if (fs.existsSync(assetsPath)) return assetsPath;
@@ -130,16 +412,16 @@ const getIconPath = () => {
 const createWindow = () => {
   const primaryDisplay = screen.getPrimaryDisplay();
   const { x, y, width, height } = primaryDisplay.bounds;
-  const isLinux = process.platform === 'linux';
-  const isWindows = process.platform === 'win32';
-  const isMac = process.platform === 'darwin';
+  const isLinux = process.platform === "linux";
+  const isWindows = process.platform === "win32";
+  const isMac = process.platform === "darwin";
 
   const winWidth = width;
   const winHeight = height;
   const winX = x;
   const winY = y;
 
-  const windowType = isWindows ? 'toolbar' : 'panel';
+  const windowType = isWindows ? "toolbar" : "panel";
 
   mainWindow = new BrowserWindow({
     width: winWidth,
@@ -162,14 +444,10 @@ const createWindow = () => {
     acceptFirstMouse: true,
     webPreferences: {
       preload: path.join(__dirname, "preload.js"),
-      devTools: false
+      devTools: false,
     },
-    show: true
+    show: true,
   });
-
-  if (!isLinux) {
-
-  }
 
   if (!isLinux) {
     mainWindow.setIgnoreMouseEvents(true, { forward: true });
@@ -179,16 +457,16 @@ const createWindow = () => {
 
   const showDelay = isLinux ? 500 : 0;
 
-  mainWindow.once('ready-to-show', () => {
+  mainWindow.once("ready-to-show", () => {
     setTimeout(() => {
       if (mainWindow) {
         mainWindow.show();
         if (isLinux) {
-          mainWindow.setAlwaysOnTop(true, 'screen-saver');
+          mainWindow.setAlwaysOnTop(true, "screen-saver");
         } else if (isMac) {
-          mainWindow.setAlwaysOnTop(true, 'pop-up-menu');
+          mainWindow.setAlwaysOnTop(true, "pop-up-menu");
         } else {
-          mainWindow.setAlwaysOnTop(true, 'pop-up-menu');
+          mainWindow.setAlwaysOnTop(true, "pop-up-menu");
         }
         mainWindow.focus();
       }
@@ -202,19 +480,21 @@ const createWindow = () => {
     }
   }, 5000);
 
-  mainWindow.on('closed', () => {
+  mainWindow.on("closed", () => {
     mainWindow = null;
   });
 
   try {
     mainWindow.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
-  } catch (_) {
-  }
+  } catch (_) {}
 
-  if (!app.isPackaged || process.env.NODE_ENV === 'development') {
+  if (!app.isPackaged || process.env.NODE_ENV === "development") {
     mainWindow.loadURL("http://localhost:5173");
   } else {
-    const rendererPath = path.join(__dirname, "../renderer/main_window/index.html");
+    const rendererPath = path.join(
+      __dirname,
+      "../renderer/main_window/index.html",
+    );
     mainWindow.loadFile(rendererPath);
   }
 };
@@ -237,7 +517,7 @@ app.whenReady().then(() => {
     tray = new Tray(trayIcon);
     const contextMenu = Menu.buildFromTemplate([
       {
-        label: 'Show/Hide Ripple',
+        label: "Show/Hide Ripple",
         click: () => {
           if (mainWindow) {
             if (mainWindow.isVisible()) {
@@ -246,32 +526,28 @@ app.whenReady().then(() => {
               mainWindow.show();
             }
           }
-        }
+        },
       },
-      { type: 'separator' },
+      { type: "separator" },
       {
-        label: 'Quit',
+        label: "Quit",
         click: () => {
           app.quit();
-        }
-      }
+        },
+      },
     ]);
-    tray.setToolTip('Ripple');
+    tray.setToolTip("Ripple");
     tray.setContextMenu(contextMenu);
   } catch (e) {
-    console.error('Failed to create tray:', e);
+    console.error("Failed to create tray:", e);
   }
 });
 
-//Keep in mind that this part was made by AI
-
-
-
-ipcMain.handle('get-system-media', async () => {
+ipcMain.handle("get-system-media", async () => {
   return new Promise((resolve) => {
     const platform = process.platform;
 
-    if (platform === 'darwin') {
+    if (platform === "darwin") {
       const script = `
             tell application "System Events"
                 set spotifyRunning to (name of every process) contains "Spotify"
@@ -316,102 +592,122 @@ ipcMain.handle('get-system-media', async () => {
         }
         const output = stdout.trim();
 
-        if (!output || output === "None" || output === "Error") return resolve(null);
+        if (!output || output === "None" || output === "Error")
+          return resolve(null);
 
-        const parts = output.split('||');
+        const parts = output.split("||");
         if (parts.length >= 4) {
           resolve({
             name: parts[2],
             artist: parts[3],
             album: parts[4],
             artwork_url: parts[5] || null,
-            state: parts[1] === 'playing' ? 'playing' : 'paused',
-            source: parts[0]
+            state: parts[1] === "playing" ? "playing" : "paused",
+            source: parts[0],
           });
         } else {
           resolve(null);
         }
       });
-
-    } else if (platform === 'win32') {
+    } else if (platform === "win32") {
       const psScript = `[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Add-Type -AssemblyName System.Runtime.WindowsRuntime; $manager = [Windows.Media.Control.GlobalSystemMediaTransportControlsSessionManager, Windows.Media.Control, ContentType = WindowsRuntime]::RequestAsync().GetAwaiter().GetResult(); $session = $manager.GetCurrentSession(); if ($session) { $props = $session.TryGetMediaPropertiesAsync().GetAwaiter().GetResult(); $playback = $session.GetPlaybackInfo(); $status = $playback.PlaybackStatus; $thumbnail = $props.Thumbnail; $artwork = ''; if ($thumbnail) { try { $stream = $thumbnail.OpenReadAsync().GetAwaiter().GetResult(); $buffer = New-Object byte[] $stream.Size; $reader = New-Object Windows.Storage.Streams.DataReader $stream; $reader.LoadAsync($stream.Size).GetAwaiter().GetResult() | Out-Null; $reader.ReadBytes($buffer); $artwork = 'data:image/png;base64,' + [Convert]::ToBase64String($buffer); $reader.Close(); $stream.Close(); } catch { } } $info = @{ Title = $props.Title; Artist = $props.Artist; Album = $props.AlbumTitle; Status = $status.ToString().ToLower(); Source = $session.SourceAppUserModelId; Artwork = $artwork }; return $info | ConvertTo-Json -Compress; } return 'null';`;
-      exec(`powershell -NoProfile -Command "${psScript}"`, { maxBuffer: 5 * 1024 * 1024, encoding: 'utf8' }, (error, stdout) => {
-        if (error || !stdout || stdout.trim() === "null" || stdout.trim() === "'null'") {
-          exec(`powershell -NoProfile -Command "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Process | Where-Object {$_.ProcessName -eq 'Spotify'} | Select-Object MainWindowTitle"`, { encoding: 'utf8' }, (err, out) => {
-            if (err || !out) return resolve(null);
-            const title = out.split('\n').find(l => l.includes('-'))?.trim();
-            if (title) {
-              const [artist, ...songParts] = title.split(' - ');
-              const song = songParts.join(' - ');
-              resolve({
-                name: song || title,
-                artist: artist || "Unknown",
-                state: 'playing',
-                source: 'Spotify'
-              });
-            } else {
-              resolve(null);
-            }
-          });
-          return;
-        }
+      exec(
+        `powershell -NoProfile -Command "${psScript}"`,
+        { maxBuffer: 5 * 1024 * 1024, encoding: "utf8" },
+        (error, stdout) => {
+          if (
+            error ||
+            !stdout ||
+            stdout.trim() === "null" ||
+            stdout.trim() === "'null'"
+          ) {
+            exec(
+              `powershell -NoProfile -Command "[Console]::OutputEncoding = [System.Text.Encoding]::UTF8; Get-Process | Where-Object {$_.ProcessName -eq 'Spotify'} | Select-Object MainWindowTitle"`,
+              { encoding: "utf8" },
+              (err, out) => {
+                if (err || !out) return resolve(null);
+                const title = out
+                  .split("\n")
+                  .find((l) => l.includes("-"))
+                  ?.trim();
+                if (title) {
+                  const [artist, ...songParts] = title.split(" - ");
+                  const song = songParts.join(" - ");
+                  resolve({
+                    name: song || title,
+                    artist: artist || "Unknown",
+                    state: "playing",
+                    source: "Spotify",
+                  });
+                } else {
+                  resolve(null);
+                }
+              },
+            );
+            return;
+          }
 
-        try {
-          const data = JSON.parse(stdout);
+          try {
+            const data = JSON.parse(stdout);
+            resolve({
+              name: data.Title || "Unknown Title",
+              artist: data.Artist || "Unknown Artist",
+              album: data.Album || "",
+              artwork_url: data.Artwork || null,
+              state: data.Status === "playing" ? "playing" : "paused",
+              source: data.Source || "System",
+            });
+          } catch (e) {
+            resolve(null);
+          }
+        },
+      );
+    } else if (platform === "linux") {
+      exec(
+        'playerctl metadata --format "{{title}}||{{artist}}||{{album}}||{{status}}"',
+        (err, stdout) => {
+          if (err || !stdout) return resolve(null);
+          const parts = stdout.trim().split("||");
           resolve({
-            name: data.Title || "Unknown Title",
-            artist: data.Artist || "Unknown Artist",
-            album: data.Album || "",
-            artwork_url: data.Artwork || null,
-            state: data.Status === 'playing' ? 'playing' : 'paused',
-            source: data.Source || 'System'
+            name: parts[0],
+            artist: parts[1],
+            album: parts[2],
+            state: parts[3].toLowerCase(),
+            source: "System",
           });
-        } catch (e) {
-          resolve(null);
-        }
-      });
-
-    } else if (platform === 'linux') {
-      exec('playerctl metadata --format "{{title}}||{{artist}}||{{album}}||{{status}}"', (err, stdout) => {
-        if (err || !stdout) return resolve(null);
-        const parts = stdout.trim().split('||');
-        resolve({
-          name: parts[0],
-          artist: parts[1],
-          album: parts[2],
-          state: parts[3].toLowerCase(),
-          source: 'System'
-        });
-      });
+        },
+      );
     } else {
       resolve(null);
     }
   });
 });
 
-ipcMain.handle('get-bluetooth-status', async () => {
+ipcMain.handle("get-bluetooth-status", async () => {
   return new Promise((resolve) => {
     const platform = process.platform;
-    if (platform === 'darwin') {
-      exec('system_profiler SPBluetoothDataType -json', (error, stdout) => {
+    if (platform === "darwin") {
+      exec("system_profiler SPBluetoothDataType -json", (error, stdout) => {
         if (error) return resolve(false);
         try {
           const data = JSON.parse(stdout);
           const bluetoothData = data.SPBluetoothDataType[0];
-          const hasConnectedDevices = bluetoothData.device_connected && bluetoothData.device_connected.length > 0;
+          const hasConnectedDevices =
+            bluetoothData.device_connected &&
+            bluetoothData.device_connected.length > 0;
           resolve(hasConnectedDevices);
         } catch (e) {
           resolve(false);
         }
       });
-    } else if (platform === 'win32') {
+    } else if (platform === "win32") {
       const psScript = `@(Get-PnpDevice -Class Bluetooth -ErrorAction SilentlyContinue | Where-Object { $_.Status -eq 'OK' -and $_.Present -eq $true -and $_.InstanceId -match 'BTHENUM' }).Count -gt 0`;
       exec(`powershell -NoProfile -Command "${psScript}"`, (error, stdout) => {
         if (error) return resolve(false);
-        resolve(stdout.trim().toLowerCase() === 'true');
+        resolve(stdout.trim().toLowerCase() === "true");
       });
-    } else if (platform === 'linux') {
-      exec('bluetoothctl devices Connected', (error, stdout) => {
+    } else if (platform === "linux") {
+      exec("bluetoothctl devices Connected", (error, stdout) => {
         if (error) return resolve(false);
         resolve(stdout.trim().length > 0);
       });
@@ -422,15 +718,15 @@ ipcMain.handle('get-bluetooth-status', async () => {
 });
 
 app.on("window-all-closed", () => {
-  if (process.platform === 'linux' && !tray) {
+  if (process.platform === "linux" && !tray) {
     app.quit();
   }
 });
 
 // System Media Controls Handler
-ipcMain.handle('control-system-media', async (event, command) => {
+ipcMain.handle("control-system-media", async (event, command) => {
   const platform = process.platform;
-  if (platform === 'darwin') {
+  if (platform === "darwin") {
     const script = `
         tell application "System Events"
             set spotifyRunning to (name of every process) contains "Spotify"
@@ -443,9 +739,9 @@ ipcMain.handle('control-system-media', async (event, command) => {
         end if
         `;
     exec(`osascript -e '${script}'`);
-  } else if (platform === 'linux') {
+  } else if (platform === "linux") {
     let cmd = command;
-    if (command === 'playpause') cmd = 'play-pause';
+    if (command === "playpause") cmd = "play-pause";
     exec(`playerctl ${cmd}`);
   }
 });

--- a/src/preload.js
+++ b/src/preload.js
@@ -9,6 +9,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   controlSystemMedia: (command) => ipcRenderer.invoke('control-system-media', command),
   openExternal: (url) => ipcRenderer.invoke('open-external', url),
   launchApp: (appName) => ipcRenderer.invoke('launch-app', appName),
+  buildAppCache: () => ipcRenderer.invoke('build-app-cache'),
+  searchApps: (query) => ipcRenderer.invoke('search-apps', query),
   getDisplays: () => ipcRenderer.invoke('get-displays'),
   setDisplay: (displayId) => ipcRenderer.invoke('set-display', displayId),
   updateWindowPosition: (xPerc, yPx) => ipcRenderer.invoke('update-window-position', xPerc, yPx),


### PR DESCRIPTION
Resolves #28 

**Changes:**
- Added robust command parsing for Windows paths with arguments
- Implemented hybrid launch strategy (`spawn` + `shell.openPath` + `PowerShell`)
- Ensures reliable launching of Win32 and UWP apps (PowerToys-aligned behavior)
- Built a localized app cache mechanism for responsive auto-suggestions in `Island.jsx`